### PR TITLE
service context

### DIFF
--- a/Frontend/user/src/Services/GetService.ts
+++ b/Frontend/user/src/Services/GetService.ts
@@ -63,7 +63,7 @@ export const ActService = GetService<IAct>(
     "http://localhost:8080/api/act"
     );
 export const ActEventService = GetService<IActEvent>(
-    "http://localhost:8080/api/act"
+    "http://localhost:8080/api/actevent"
     );
 export const UserService = GetService<IUser>(
     "http://localhost:8080/api/user"

--- a/Frontend/user/src/assets/Voting/VotingList.tsx
+++ b/Frontend/user/src/assets/Voting/VotingList.tsx
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
 import VotingItem from './VotingItem';
 import { IActEvent, IActEventItemProps, IActEventListProps } from '../../Interfaces/IAct';
+import { ActEventService } from '../../Services/GetService';
+
+const ACTEVENT_ID = 1; // Replace '1' with the actual value you want to use
+ActEventService.getById(ACTEVENT_ID).then((result) => {
+    console.log(result);
+});
 
 // Sample data
 const tempOptionsDATA: IActEvent[] = [


### PR DESCRIPTION
Updated the URL in the GetService module for ActEventService to point to "http://localhost:8080/api/actevent" instead of "http://localhost:8080/api/act". This change ensures that the correct API endpoint is used for retrieving ActEvent data.